### PR TITLE
Resolved bug in software information page's document title due to missing template string

### DIFF
--- a/src/softwareInformationPage/SoftwareInformation.component.jsx
+++ b/src/softwareInformationPage/SoftwareInformation.component.jsx
@@ -17,7 +17,7 @@ const SoftwareInformationPage = () => {
   return (
     <Container>
       <Helmet>
-        <title>Software Repository | {softwareObject.name} </title>
+        <title>{`Software Repository | ${softwareObject.name}`}</title>
       </Helmet>
       <Row className="mt-5">
         <Col md={8} xl={6}>


### PR DESCRIPTION
- Resolved bug in software information page's document title due to missing template string