### PR TITLE
Adoption of `loadCSS` pattern to defer non critical css in this case `bootstrap` css

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,12 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
-      integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
-      crossorigin="anonymous"
-    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
+      crossorigin="anonymous" media="print" onload="this.media='all'; this.onload=null;">
     <title>Software Repository</title>
   </head>
   <body>

--- a/src/pages/softwareInformationPage/SoftwareInformationPage.component.jsx
+++ b/src/pages/softwareInformationPage/SoftwareInformationPage.component.jsx
@@ -279,7 +279,7 @@ const SoftwareInformationPage = () => {
                         </Tooltip>
                       )}
                     >
-                      <span className="d-inline-block">
+                      <span className="d-inline-block mt-2">
                         <Button
                           className="mr-2"
                           variant="outline-primary"
@@ -293,13 +293,9 @@ const SoftwareInformationPage = () => {
                       </span>
                     </OverlayTrigger>
                     <OverlayTrigger
-                      overlay={(
-                        <Tooltip>
-                          Access Software Homepage
-                        </Tooltip>
-                      )}
+                      overlay={<Tooltip>Access Software Homepage</Tooltip>}
                     >
-                      <span className="d-inline-block">
+                      <span className="d-inline-block mt-2">
                         <Button
                           variant="outline-primary"
                           href={softwareObject.homePage}
@@ -310,6 +306,7 @@ const SoftwareInformationPage = () => {
                         </Button>
                       </span>
                     </OverlayTrigger>
+
                   </Card.Text>
                 </Card.Body>
               </Card>
@@ -414,7 +411,7 @@ const SoftwareInformationPage = () => {
               </Card>
             </Col>
           </Row>
-          <Row className="justify-content-center mt-5 text-right">
+          <Row className="justify-content-center mt-4 mb-3 text-right">
             <Col md={10} id="edit-delete-buttons">
               <Button
                 className="mr-2"


### PR DESCRIPTION
- Adoption of [`loadCSS`](https://github.com/filamentgroup/loadCSS) pattern to defer non critical css and load css asynchronously in this case `bootstrap` css
- As recommended by [`Google LightHouse`](https://web.dev/defer-non-critical-css/) to defer non critical css to improve web performance (eliminating render-blocking resources)
- Improved responsiveness of `SoftwareInformationPage` component for the `Software Twitter` and `Software Homepage`, `Edit` and `Delete` buttons