### PR TITLE
Resolved bug in `AccountSettings` component password change logic where previously there was no check that the new password should be different from the old password

### DIFF
--- a/src/components/accountSettings/AccountSettings.component.jsx
+++ b/src/components/accountSettings/AccountSettings.component.jsx
@@ -28,9 +28,17 @@ const AccountSettings = () => {
 
     setValidated(false);
 
+    if (oldPassword === newPassword) {
+      handleNotification(
+        'Please ensure that the new password is different from the old password.',
+        'danger',
+      );
+      return false;
+    }
+
     if (newPassword !== confirmNewPassword) {
       handleNotification(
-        'Please ensure the new password and confirm new password matches.',
+        'Please ensure that the new password and confirm new password matches.',
         'danger',
       );
       return false;


### PR DESCRIPTION
- Resolved bug in `AccountSettings` component password change logic where previously there was no check that the new password should be different from the old password

This is to avoid unnecessary API calls to change password when the old password and desired new password are equal (Optimisation)